### PR TITLE
Fix broken scroll and offset calculation

### DIFF
--- a/lib/breadcrumb-view.coffee
+++ b/lib/breadcrumb-view.coffee
@@ -49,16 +49,15 @@ class BreadcrumbView extends View
     parents.unshift n for n in node.parents('.directory')
     parents.shift()
 
-    path = []
-
     parents.forEach (node, i) ->
-      label = $(node).children('.header').text()
-      path.push label
+      name = $(node).find('> .header > .name')
+      label = name.text()
+
       cls = 'btn'
       cls += ' btn-primary' if i is parents.length - 1
 
       html.push """
-        <div class='#{cls}' data-target='#{path.join('/')}'>
+        <div class='#{cls}' data-target='#{name[0].dataset.path}'>
           #{label}
         </div>
       """
@@ -73,7 +72,7 @@ class BreadcrumbView extends View
     offset = item.offset()
     if offset?
       newScroll = offset.top + oldScroll - @breadcrumb.height()
-      @treeViewScroller.scrollTop(newScroll)
+      @treeViewScroller.scrollTop(newScroll - @treeViewScroller.offset().top)
 
   treeViewScrolled: =>
     scrollTop = @treeViewScroller.scrollTop()


### PR DESCRIPTION
Not sure when this happened but the `data-path` attribute is now the full path to the file, and we can just use it as the target of the breadcrumb button as-is. 

Also fix the scroll position when the tree-view is positioned lower than the top of the document.
